### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   PROJECT_ID: bytes-and-nibbles
   NODE_VERSION: 24
@@ -51,6 +54,9 @@ jobs:
     name: Build and preview
     runs-on: ubuntu-latest
     needs: [test, lint]
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Samuel-Harris/Bytes-and-Nibbles-Website/security/code-scanning/1](https://github.com/Samuel-Harris/Bytes-and-Nibbles-Website/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for all jobs. Based on the workflow's functionality:
- The `test` and `lint` jobs only need `contents: read` to access the repository code.
- The `build_and_preview` job requires `contents: read` and possibly `pages: write` or `deployments: write` for the Firebase preview step, depending on the Firebase action's requirements.

We will set `contents: read` globally and add job-specific permissions for `build_and_preview` if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
